### PR TITLE
[bouncy] add package.xml patch for bouncy

### DIFF
--- a/bouncy/package.xml
+++ b/bouncy/package.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ros1_bridge</name>
+  <version>0.4.0</version>
+  <description>A simple bridge between ROS 1 and ROS 2</description>
+  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_index_python</buildtool_depend>
+  <buildtool_depend>python3-catkin-pkg-modules</buildtool_depend>
+  <buildtool_depend>rosidl_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_parser</buildtool_depend>
+
+  <build_depend>builtin_interfaces</build_depend>
+  <build_depend>pkg-config</build_depend>
+  <build_depend>python3-yaml</build_depend>
+  <build_depend>rclcpp</build_depend>
+  <build_depend>rcutils</build_depend>
+  <build_depend>rmw_implementation_cmake</build_depend>
+  <build_depend>std_msgs</build_depend>
+
+  <exec_depend>builtin_interfaces</exec_depend>
+  <exec_depend>python3-yaml</exec_depend>
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rcutils</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>demo_nodes_cpp</test_depend>
+  <test_depend>diagnostic_msgs</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>ros2run</test_depend>
+
+  <group_depend>rosidl_interface_packages</group_depend>
+
+  <!-- Bundles useful msgs and srvs packages for binary release -->
+  <depend>actionlib_msgs</depend>
+  <depend>diagnostic_msgs</depend>
+  <depend>example_interfaces</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>rosgraph_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>shape_msgs</depend>
+  <depend>std_srvs</depend>
+  <depend>stereo_msgs</depend>
+  <depend>tf2_msgs</depend>
+  <depend>trajectory_msgs</depend>
+  <depend>visualization_msgs</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/bouncy/package.xml
+++ b/bouncy/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros1_bridge</name>
-  <version>0.4.0</version>
+  <version>:{version}</version>
   <description>A simple bridge between ROS 1 and ROS 2</description>
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
this adds dependencies on all ROS2 interface packages we want to compile the bridge for:

 - actionlib_msgs
 - diagnostic_msgs
 - example_interfaces
 - geometry_msgs
 - nav_msgs
 - rosgraph_msgs
 - sensor_msgs
 - shape_msgs
 - std_srvs
 - stereo_msgs
 - tf2_msgs
 - trajectory_msgs
 - visualization_msgs

Dependencies already listed in source package.xml:
 - builtin_interfaces
 - std_msgs