### PR TITLE
Update package.xml with `example_interfaces`

### DIFF
--- a/debian/package.xml
+++ b/debian/package.xml
@@ -37,6 +37,8 @@
   <exec_depend>actionlib_msgs</exec_depend>
   <build_depend>diagnostic_msgs</build_depend>
   <exec_depend>diagnostic_msgs</exec_depend>
+  <build_depend>example_interfaces</build_depend>
+  <exec_depend>example_interfaces</exec_depend>
   <build_depend>geometry_msgs</build_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <build_depend>nav_msgs</build_depend>


### PR DESCRIPTION
Should hopefully help to build http://build.ros2.org/job/Cbin_ubv8_uBv8__rosbag2_bag_v2_plugins__ubuntu_bionic_arm64__binary/30/

I believe a new `.deb` for the `ros1_bridge` is needed.