### PR TITLE
Add useful interface packages.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -39,6 +39,36 @@
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>ros2run</test_depend>
 
+  <!-- Bundles useful msgs and srvs packages for binary release -->
+  <build_depend>action_msgs</build_depend>
+  <exec_depend>action_msgs</exec_depend>
+  <build_depend>actionlib_msgs</build_depend>
+  <exec_depend>actionlib_msgs</exec_depend>
+  <build_depend>diagnostic_msgs</build_depend>
+  <exec_depend>diagnostic_msgs</exec_depend>
+  <build_depend>example_interfaces</build_depend>
+  <exec_depend>example_interfaces</exec_depend>
+  <build_depend>gazebo_msgs</build_depend>
+  <exec_depend>gazebo_msgs</exec_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <build_depend>nav_msgs</build_depend>
+  <exec_depend>nav_msgs</exec_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <build_depend>shape_msgs</build_depend>
+  <exec_depend>shape_msgs</exec_depend>
+  <build_depend>std_srvs</build_depend>
+  <exec_depend>std_srvs</exec_depend>
+  <build_depend>stereo_msgs</build_depend>
+  <exec_depend>stereo_msgs</exec_depend>
+  <build_depend>tf2_msgs</build_depend>
+  <exec_depend>tf2_msgs</exec_depend>
+  <build_depend>trajectory_msgs</build_depend>
+  <exec_depend>trajectory_msgs</exec_depend>
+  <build_depend>visualization_msgs</build_depend>
+  <exec_depend>visualization_msgs</exec_depend>
+
   <group_depend>rosidl_interface_packages</group_depend>
 
   <export>


### PR DESCRIPTION
Group dependencies aren't handled by bloom so these need to be added for
binary releases.

Fixes #7 

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>