### PR TITLE
Add dependencies on demo packages for Eloquent.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -44,6 +44,10 @@
   <exec_depend>action_msgs</exec_depend>
   <build_depend>actionlib_msgs</build_depend>
   <exec_depend>actionlib_msgs</exec_depend>
+  <build_depend>demo_nodes_cpp</build_depend>
+  <exec_depend>demo_nodes_cpp</exec_depend>
+  <build_depend>demo_nodes_py</build_depend>
+  <exec_depend>demo_nodes_py</exec_depend>
   <build_depend>diagnostic_msgs</build_depend>
   <exec_depend>diagnostic_msgs</exec_depend>
   <build_depend>example_interfaces</build_depend>


### PR DESCRIPTION
Part of the resolution of https://github.com/ros2/ros1_bridge/issues/228 for Eloquent. The ROS 1 dependencies are injected directly into the Debian control data as there's no way for rosdep to resolve cross-rosdistro dependencies.