### PR TITLE
Add gazebo_msgs dependency to package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -46,6 +46,8 @@
   <exec_depend>diagnostic_msgs</exec_depend>
   <build_depend>example_interfaces</build_depend>
   <exec_depend>example_interfaces</exec_depend>
+  <build_depend>gazebo_msgs</build_depend>
+  <exec_depend>gazebo_msgs</exec_depend>
   <build_depend>geometry_msgs</build_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <build_depend>nav_msgs</build_depend>


### PR DESCRIPTION
Currently not all gazebo services are forwarded from ROS to ROS2. This pull request solves the issue.

It is described [here](https://answers.ros.org/question/359849/ros2-foxy-ros1_bridge/) in more details.